### PR TITLE
add failing test for / combo use case

### DIFF
--- a/specs/router.spec.php
+++ b/specs/router.spec.php
@@ -128,6 +128,20 @@ describe('Router', function () {
 
             expect($executed)->to->be->true;
         });
+
+        it('should dispatch a registered $_POST route when scope param is in the query string', function () {
+            $_GET = ['scoped_action' => '/custom-endpoint'];
+            $_SERVER = ['REQUEST_METHOD' => 'POST'];
+
+            $executed = false;
+            $this->router->post('/custom-endpoint', function () use (&$executed) {
+                $executed = true;
+            });
+
+            $this->router->dispatch();
+
+            expect($executed)->to->be->true;
+        });
     });
 
 });


### PR DESCRIPTION
# YOLO.  This package looks super sweet. You are a grand, majestic, neck-bearded savant.

This PR isn't really something you have to accept or anything, but I forked and cloned and thought this would be a decent place to communicate.

In reading through all the code, the only things that stuck out to me were these things three:

First is shown in the added failing test.  In looking through the tests I wondered if I could do stuff in javascript like this:

``` js
$.ajax(function() {
  url: "http://neckbeard.com/?my_scope=/foo,
  data: JSON.stringify({foo: "bar"})
});
```

And then register my route listener like so:

``` php
$router = new Router('my_scope');
$router->post('/foo', function () {
    $data = json_decode(file_get_contents('php://input'), true);
    // $data is now exactly ['foo' => 'bar']'
    // and I can use it directly without pulling out the scope param
});
```

That way, we could have a json post body payload with everything we want the server to consume, and leave the route slug in the query string, even though we're registering a `$_POST` request.  Does that make sense?  Hopefully it does. I immediately thought to myself, I would want to register it like this, I wonder if it works.

Second, I had a hair bit of trouble running the tests. I tried first:

```
$ vendor/bin/peridot
```

But it ran the Router tests and all of the Peridot tests, many of which were failing.  So I looked at the Peridot docs (excellent, by the way!) and figured out I could do the following, which worked:

```
vendor/bin/peridot -b -g rou*.spec.php
```

Third, I was a hair confused by https://github.com/netrivet/wp-router/blob/master/src/Router.php#L100 . What is the `$params` arg for?  Couldn't figure it out.  Is it just a convenience for testing?

Anyway, these are all super little things -- overall I love, love, love it.  The code is super lovely, and I was happy to play with Peridot a little bit.  The reflection into the closures is rad as well. :neckbeard: :poultry_leg: 
